### PR TITLE
Amazon widget is slightly too large

### DIFF
--- a/widgets/amazon_price/amazon_price.scss
+++ b/widgets/amazon_price/amazon_price.scss
@@ -9,7 +9,7 @@ $label-color:       rgba(255, 255, 255, 0.7);
 .widget-amazon-price {
 
 .value {
-  font-size: 65px;
+  font-size: 59px;
 
 }
 


### PR DESCRIPTION
Reduce the font by just a little bit so the widget stays square.